### PR TITLE
Update readable-stream

### DIFF
--- a/example/stream.js
+++ b/example/stream.js
@@ -1,13 +1,13 @@
-var block = require('../');
-var through = require('through2');
+const through = require('through2')
+const block = require('../')
 
 process.stdin
-    .pipe(block({ size: 16, zeroPadding: true }))
-    .pipe(through(function (buf, enc, next) {
-        var str = buf.toString().replace(/[\x00-\x1f]/g, chr);
-        console.log('buf[' + buf.length + ']=' + str);
-        next();
-    }))
-;
-function chr (s) { return '\\x' + pad(s.charCodeAt(0).toString(16),2) }
+  .pipe(block({ size: 16, zeroPadding: true }))
+  .pipe(through((buf, enc, next) => {
+    const str = buf.toString().replace(/[\x00-\x1f]/g, chr)
+    console.log(`buf[${buf.length}]=${str}`)
+    next()
+  }))
+
+function chr (s) { return `\\x${pad(s.charCodeAt(0).toString(16), 2)}` }
 function pad (s, n) { return Array(n - s.length + 1).join('0') + s }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { Transform } = require('readable-stream')
 
 class Block extends Transform {
   constructor (size, opts = {}) {
-    super()
+    super(opts)
 
     if (typeof size === 'object') {
       opts = size

--- a/index.js
+++ b/index.js
@@ -1,51 +1,50 @@
-var inherits = require('inherits');
-var Transform = require('readable-stream').Transform;
-var defined = require('defined');
+const { Transform } = require('readable-stream')
 
-module.exports = Block;
-inherits(Block, Transform);
+class Block extends Transform {
+  constructor (size, opts = {}) {
+    super()
 
-function Block (size, opts) {
-    if (!(this instanceof Block)) return new Block(size, opts);
-    Transform.call(this);
-    if (!opts) opts = {};
     if (typeof size === 'object') {
-        opts = size;
-        size = opts.size;
+      opts = size
+      size = opts.size
     }
-    this.size = size || 512;
-    
-    if (opts.nopad) this._zeroPadding = false;
-    else this._zeroPadding = defined(opts.zeroPadding, true);
-    
-    this._buffered = [];
-    this._bufferedBytes = 0;
+
+    this.size = size || 512
+
+    const { nopad, zeroPadding = true } = opts
+
+    if (nopad) this._zeroPadding = false
+    else this._zeroPadding = !!zeroPadding
+
+    this._buffered = []
+    this._bufferedBytes = 0
+  }
+
+  _transform (buf, enc, next) {
+    this._bufferedBytes += buf.length
+    this._buffered.push(buf)
+
+    while (this._bufferedBytes >= this.size) {
+      const b = Buffer.concat(this._buffered)
+      this._bufferedBytes -= this.size
+      this.push(b.slice(0, this.size))
+      this._buffered = [ b.slice(this.size, b.length) ]
+    }
+    next()
+  }
+
+  _flush () {
+    if (this._bufferedBytes && this._zeroPadding) {
+      const zeroes = Buffer.alloc(this.size - this._bufferedBytes)
+      this._buffered.push(zeroes)
+      this.push(Buffer.concat(this._buffered))
+      this._buffered = null
+    } else if (this._bufferedBytes) {
+      this.push(Buffer.concat(this._buffered))
+      this._buffered = null
+    }
+    this.push(null)
+  }
 }
 
-Block.prototype._transform = function (buf, enc, next) {
-    this._bufferedBytes += buf.length;
-    this._buffered.push(buf);
-    
-    while (this._bufferedBytes >= this.size) {
-        var b = Buffer.concat(this._buffered);
-        this._bufferedBytes -= this.size;
-        this.push(b.slice(0, this.size));
-        this._buffered = [ b.slice(this.size, b.length) ];
-    }
-    next();
-};
-
-Block.prototype._flush = function () {
-    if (this._bufferedBytes && this._zeroPadding) {
-        var zeroes = new Buffer(this.size - this._bufferedBytes);
-        zeroes.fill(0);
-        this._buffered.push(zeroes);
-        this.push(Buffer.concat(this._buffered));
-        this._buffered = null;
-    }
-    else if (this._bufferedBytes) {
-        this.push(Buffer.concat(this._buffered));
-        this._buffered = null;
-    }
-    this.push(null);
-};
+module.exports = Block

--- a/package.json
+++ b/package.json
@@ -1,12 +1,10 @@
 {
   "name": "block-stream2",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "transform input into equally-sized blocks of output",
   "main": "index.js",
   "dependencies": {
-    "defined": "^1.0.0",
-    "inherits": "^2.0.1",
-    "readable-stream": "^2.0.4"
+    "readable-stream": "^3.0.2"
   },
   "devDependencies": {
     "tape": "^4.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-stream2",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "transform input into equally-sized blocks of output",
   "main": "index.js",
   "dependencies": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -10,45 +10,45 @@ streams2 version of
 # example
 
 ``` js
-var block = require('block-stream2');
-var through = require('through2');
+const block = require('block-stream2');
+const through = require('through2');
 
 process.stdin
     .pipe(block({ size: 16, zeroPadding: true }))
-    .pipe(through(function (buf, enc, next) {
-        var str = buf.toString().replace(/[\x00-\x1f]/g, chr);
-        console.log('buf[' + buf.length + ']=' + str);
+    .pipe(through((buf, enc, next) => {
+        const str = buf.toString().replace(/[\x00-\x1f]/g, chr);
+        console.log(`buf[${buf.length}]=${str}`);
         next();
     }))
 ;
-function chr (s) { return '\\x' + pad(s.charCodeAt(0).toString(16),2) }
+function chr (s) { return `\\x${pad(s.charCodeAt(0).toString(16),2)}` }
 function pad (s, n) { return Array(n - s.length + 1).join('0') + s }
 ```
 
 ```
 $ echo {c,d,f}{a,e,i,o,u}{t,g,r} | node example/stream.js
-buf[16]=cat cag car cet 
-buf[16]=ceg cer cit cig 
-buf[16]=cir cot cog cor 
-buf[16]=cut cug cur dat 
-buf[16]=dag dar det deg 
-buf[16]=der dit dig dir 
-buf[16]=dot dog dor dut 
-buf[16]=dug dur fat fag 
-buf[16]=far fet feg fer 
-buf[16]=fit fig fir fot 
-buf[16]=fog for fut fug 
+buf[16]=cat cag car cet
+buf[16]=ceg cer cit cig
+buf[16]=cir cot cog cor
+buf[16]=cut cug cur dat
+buf[16]=dag dar det deg
+buf[16]=der dit dig dir
+buf[16]=dot dog dor dut
+buf[16]=dug dur fat fag
+buf[16]=far fet feg fer
+buf[16]=fit fig fir fot
+buf[16]=fog for fut fug
 buf[16]=fur\x0a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00
 ```
 
 # methods
 
 ``` js
-var block = require('block-stream2');
+const block = require('block-stream2');
 ```
 
-## var b = block(opts)
-## var b = block(size, opts)
+## const b = block(opts)
+## const b = block(size, opts)
 
 Create a new transform stream `b` that outputs chunks of length `size` or
 `opts.size`.

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,28 +1,27 @@
-var test = require('tape')
-  , BlockStream = require("../")
+const test = require('tape')
+const BlockStream = require('../')
 
-test("basic test", function (t) {
-  var b = new BlockStream(16)
-  var fs = require("fs")
-  var fstr = fs.createReadStream(__filename, {encoding: "utf8"})
+test('basic test', t => {
+  const b = new BlockStream(16)
+  const fs = require('fs')
+  const fstr = fs.createReadStream(__filename, { encoding: 'utf8' })
   fstr.pipe(b)
-  b.resume();
+  b.resume()
 
-  var stat
-  t.doesNotThrow(function () {
+  let stat
+  t.doesNotThrow(() => {
     stat = fs.statSync(__filename)
-  }, "stat should not throw")
+  }, 'stat should not throw')
 
-  var totalBytes = 0
-  b.on("data", function (c) {
-    t.equal(c.length, 16, "chunks should be 16 bytes long")
-    t.ok(Buffer.isBuffer(c), "chunks should be buffer objects")
+  let totalBytes = 0
+  b.on('data', c => {
+    t.equal(c.length, 16, 'chunks should be 16 bytes long')
+    t.ok(Buffer.isBuffer(c), 'chunks should be buffer objects')
     totalBytes += c.length
   })
-  b.on("end", function () {
-    var expectedBytes = stat.size + (16 - stat.size % 16)
-    t.equal(totalBytes, expectedBytes, "Should be multiple of 16")
+  b.on('end', () => {
+    const expectedBytes = stat.size + (16 - stat.size % 16)
+    t.equal(totalBytes, expectedBytes, 'Should be multiple of 16')
     t.end()
   })
-
 })

--- a/test/nopad-thorough.js
+++ b/test/nopad-thorough.js
@@ -1,68 +1,68 @@
-var BlockStream = require("../")
+const test = require('tape')
+const BlockStream = require('../')
 
-var blockSizes = [16]//, 25]//, 1024]
-  , writeSizes = [4, 15, 16, 17, 64 ]//, 64, 100]
-  , writeCounts = [1, 10]//, 100]
-  , test = require('tape')
+const blockSizes = [16] //, 25]//, 1024]
+const writeSizes = [4, 15, 16, 17, 64] //, 64, 100]
+const writeCounts = [1, 10] //, 100]
 
-writeCounts.forEach(function (writeCount) {
-blockSizes.forEach(function (blockSize) {
-writeSizes.forEach(function (writeSize) {
-  test("writeSize=" + writeSize +
-           " blockSize="+blockSize +
-           " writeCount="+writeCount, function (t) {
-    var f = new BlockStream(blockSize, {nopad: true })
+writeCounts.forEach(writeCount => {
+  blockSizes.forEach(blockSize => {
+    writeSizes.forEach(writeSize => {
+      test(`writeSize=${writeSize} blockSize=${blockSize} writeCount=${writeCount}`, t => {
+        const f = new BlockStream(blockSize, { nopad: true })
 
-    var actualChunks = 0
-    var actualBytes = 0
-    var timeouts = 0
+        let actualChunks = 0
+        let actualBytes = 0
+        let timeouts = 0
 
-    f.on("data", function (c) {
-      timeouts ++
+        f.on('data', c => {
+          timeouts++
 
-      actualChunks ++
-      actualBytes += c.length
+          actualChunks++
+          actualBytes += c.length
 
-      // make sure that no data gets corrupted, and basic sanity
-      var before = c.toString()
-      // simulate a slow write operation
-      setTimeout(function () {
-        timeouts --
+          // make sure that no data gets corrupted, and basic sanity
+          const before = c.toString()
+          // simulate a slow write operation
+          setTimeout(() => {
+            timeouts--
 
-        var after = c.toString()
-        t.equal(after, before, "should not change data")
+            const after = c.toString()
+            t.equal(after, before, 'should not change data')
 
-        // now corrupt it, to find leaks.
-        for (var i = 0; i < c.length; i ++) {
-          c[i] = "x".charCodeAt(0)
+            // now corrupt it, to find leaks.
+            for (let i = 0; i < c.length; i++) {
+              c[i] = 'x'.charCodeAt(0)
+            }
+          }, 100)
+        })
+
+        f.on('end', () => {
+          // round up to the nearest block size
+          const expectChunks = Math.ceil(writeSize * writeCount * 2 / blockSize)
+          const expectBytes = writeSize * writeCount * 2
+          t.equal(actualBytes, expectBytes,
+            `bytes=${expectBytes} writeSize=${writeSize}`)
+          t.equal(actualChunks, expectChunks,
+            `chunks=${expectChunks} writeSize=${writeSize}`)
+
+          // wait for all the timeout checks to finish, then end the test
+          setTimeout(function WAIT () {
+            if (timeouts > 0) return setTimeout(WAIT)
+            t.end()
+          }, 100)
+        })
+
+        for (let i = 0; i < writeCount; i++) {
+          const a = Buffer.alloc(writeSize)
+          for (let j = 0; j < writeSize; j++) a[j] = 'a'.charCodeAt(0)
+          const b = Buffer.alloc(writeSize)
+          for (let j = 0; j < writeSize; j++) b[j] = 'b'.charCodeAt(0)
+          f.write(a)
+          f.write(b)
         }
-      }, 100)
+        f.end()
+      })
     })
-
-    f.on("end", function () {
-      // round up to the nearest block size
-      var expectChunks = Math.ceil(writeSize * writeCount  * 2 / blockSize)
-      var expectBytes = writeSize * writeCount * 2
-      t.equal(actualBytes, expectBytes,
-              "bytes=" + expectBytes + " writeSize=" + writeSize)
-      t.equal(actualChunks, expectChunks,
-              "chunks=" + expectChunks + " writeSize=" + writeSize)
-
-      // wait for all the timeout checks to finish, then end the test
-      setTimeout(function WAIT () {
-        if (timeouts > 0) return setTimeout(WAIT)
-        t.end()
-      }, 100)
-    })
-
-    for (var i = 0; i < writeCount; i ++) {
-      var a = new Buffer(writeSize);
-      for (var j = 0; j < writeSize; j ++) a[j] = "a".charCodeAt(0)
-      var b = new Buffer(writeSize);
-      for (var j = 0; j < writeSize; j ++) b[j] = "b".charCodeAt(0)
-      f.write(a)
-      f.write(b)
-    }
-    f.end()
   })
-}) }) })
+})

--- a/test/nopad.js
+++ b/test/nopad.js
@@ -1,57 +1,56 @@
-var BlockStream = require("../")
-var tap = { test: require("tape") }
+const BlockStream = require('../')
+const test = require('tape')
 
-
-tap.test("don't pad, small writes", function (t) {
-  var f = new BlockStream(16, { nopad: true })
+test("don't pad, small writes", t => {
+  const f = new BlockStream(16, { nopad: true })
   t.plan(1)
 
-  f.on("data", function (c) {
-    t.equal(c.toString(), "abc", "should get 'abc'")
+  f.on('data', c => {
+    t.equal(c.toString(), 'abc', "should get 'abc'")
   })
 
-  f.on("end", function () { t.end() })
+  f.on('end', () => { t.end() })
 
-  f.write(new Buffer("a"))
-  f.write(new Buffer("b"))
-  f.write(new Buffer("c"))
+  f.write(Buffer.from('a'))
+  f.write(Buffer.from('b'))
+  f.write(Buffer.from('c'))
   f.end()
 })
 
-tap.test("don't pad, exact write", function (t) {
-  var f = new BlockStream(16, { nopad: true })
+test("don't pad, exact write", t => {
+  const f = new BlockStream(16, { nopad: true })
   t.plan(1)
 
-  var first = true
-  f.on("data", function (c) {
+  let first = true
+  f.on('data', c => {
     if (first) {
       first = false
-      t.equal(c.toString(), "abcdefghijklmnop", "first chunk")
+      t.equal(c.toString(), 'abcdefghijklmnop', 'first chunk')
     } else {
-      t.fail("should only get one")
+      t.fail('should only get one')
     }
   })
 
-  f.on("end", function () { t.end() })
+  f.on('end', () => { t.end() })
 
-  f.end(new Buffer("abcdefghijklmnop"))
+  f.end(Buffer.from('abcdefghijklmnop'))
 })
 
-tap.test("don't pad, big write", function (t) {
-  var f = new BlockStream(16, { nopad: true })
+test("don't pad, big write", t => {
+  const f = new BlockStream(16, { nopad: true })
   t.plan(2)
 
-  var first = true
-  f.on("data", function (c) {
+  let first = true
+  f.on('data', c => {
     if (first) {
       first = false
-      t.equal(c.toString(), "abcdefghijklmnop", "first chunk")
+      t.equal(c.toString(), 'abcdefghijklmnop', 'first chunk')
     } else {
-      t.equal(c.toString(), "q")
+      t.equal(c.toString(), 'q')
     }
   })
 
-  f.on("end", function () { t.end() })
+  f.on('end', () => { t.end() })
 
-  f.end(new Buffer("abcdefghijklmnopq"))
+  f.end(Buffer.from('abcdefghijklmnopq'))
 })

--- a/test/thorough.js
+++ b/test/thorough.js
@@ -1,68 +1,68 @@
-var BlockStream = require("../")
+const test = require('tape')
+const BlockStream = require('../')
 
-var blockSizes = [16]//, 25]//, 1024]
-  , writeSizes = [4, 15, 16, 17, 64 ]//, 64, 100]
-  , writeCounts = [1, 10]//, 100]
-  , test = require('tape')
+const blockSizes = [16] //, 25]//, 1024]
+const writeSizes = [4, 15, 16, 17, 64] //, 64, 100]
+const writeCounts = [1, 10] //, 100]
 
-writeCounts.forEach(function (writeCount) {
-blockSizes.forEach(function (blockSize) {
-writeSizes.forEach(function (writeSize) {
-  test("writeSize=" + writeSize +
-           " blockSize="+blockSize +
-           " writeCount="+writeCount, function (t) {
-    var f = new BlockStream(blockSize)
+writeCounts.forEach(writeCount => {
+  blockSizes.forEach(blockSize => {
+    writeSizes.forEach(writeSize => {
+      test(`writeSize=${writeSize} blockSize=${blockSize} writeCount=${writeCount}`, t => {
+        const f = new BlockStream(blockSize)
 
-    var actualChunks = 0
-    var actualBytes = 0
-    var timeouts = 0
+        let actualChunks = 0
+        let actualBytes = 0
+        let timeouts = 0
 
-    f.on("data", function (c) {
-      timeouts ++
+        f.on('data', c => {
+          timeouts++
 
-      actualChunks ++
-      actualBytes += c.length
+          actualChunks++
+          actualBytes += c.length
 
-      // make sure that no data gets corrupted, and basic sanity
-      var before = c.toString()
-      // simulate a slow write operation
-      setTimeout(function () {
-        timeouts --
+          // make sure that no data gets corrupted, and basic sanity
+          const before = c.toString()
+          // simulate a slow write operation
+          setTimeout(() => {
+            timeouts--
 
-        var after = c.toString()
-        t.equal(after, before, "should not change data")
+            const after = c.toString()
+            t.equal(after, before, 'should not change data')
 
-        // now corrupt it, to find leaks.
-        for (var i = 0; i < c.length; i ++) {
-          c[i] = "x".charCodeAt(0)
+            // now corrupt it, to find leaks.
+            for (let i = 0; i < c.length; i++) {
+              c[i] = 'x'.charCodeAt(0)
+            }
+          }, 100)
+        })
+
+        f.on('end', () => {
+          // round up to the nearest block size
+          const expectChunks = Math.ceil(writeSize * writeCount * 2 / blockSize)
+          const expectBytes = expectChunks * blockSize
+          t.equal(actualBytes, expectBytes,
+            `bytes=${expectBytes} writeSize=${writeSize}`)
+          t.equal(actualChunks, expectChunks,
+            `chunks=${expectChunks} writeSize=${writeSize}`)
+
+          // wait for all the timeout checks to finish, then end the test
+          setTimeout(function WAIT () {
+            if (timeouts > 0) return setTimeout(WAIT)
+            t.end()
+          }, 100)
+        })
+
+        for (let i = 0; i < writeCount; i++) {
+          const a = Buffer.alloc(writeSize)
+          for (let j = 0; j < writeSize; j++) a[j] = 'a'.charCodeAt(0)
+          const b = Buffer.alloc(writeSize)
+          for (let j = 0; j < writeSize; j++) b[j] = 'b'.charCodeAt(0)
+          f.write(a)
+          f.write(b)
         }
-      }, 100)
+        f.end()
+      })
     })
-
-    f.on("end", function () {
-      // round up to the nearest block size
-      var expectChunks = Math.ceil(writeSize * writeCount  * 2 / blockSize)
-      var expectBytes = expectChunks * blockSize
-      t.equal(actualBytes, expectBytes,
-              "bytes=" + expectBytes + " writeSize=" + writeSize)
-      t.equal(actualChunks, expectChunks,
-              "chunks=" + expectChunks + " writeSize=" + writeSize)
-
-      // wait for all the timeout checks to finish, then end the test
-      setTimeout(function WAIT () {
-        if (timeouts > 0) return setTimeout(WAIT)
-        t.end()
-      }, 100)
-    })
-
-    for (var i = 0; i < writeCount; i ++) {
-      var a = new Buffer(writeSize);
-      for (var j = 0; j < writeSize; j ++) a[j] = "a".charCodeAt(0)
-      var b = new Buffer(writeSize);
-      for (var j = 0; j < writeSize; j ++) b[j] = "b".charCodeAt(0)
-      f.write(a)
-      f.write(b)
-    }
-    f.end()
   })
-}) }) })
+})


### PR DESCRIPTION
Hi, I don't directly use block-stream2 but one of your dependency is outdated (readable-stream v2)

I have another package that uses readable-stream v3 and your v2 is making lots of duplicated code

I updated your code to use es6 that is compatible with latest node LTS ( node v6 )
therefore i removed inherits and replaced it with class extends, i also didn't see any need for `defined` to be included.

And now you can't call `Block()` without `new` since it uses classes And readable-stream made a major update so i thought a new major version where in place here to

I have also changed the deprecated buffer constructor to use the new function `.from(), alloc()`

I also saw some inconsistent code style format so i applied standard js